### PR TITLE
default required_status_checks_strict to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -133,7 +133,7 @@ variable "required_status_checks" {
 variable "required_status_checks_strict" {
   description = "https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection#strict"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "dismiss_stale_reviews" {


### PR DESCRIPTION
Setting to false by default to better support dependabot PRs. Currently, having multiple parallel dependabot PRs will bring all the workflows to a halt as they have to be updated serially without any automation.